### PR TITLE
487-fixes-header-search

### DIFF
--- a/templates/page--front.tpl.php
+++ b/templates/page--front.tpl.php
@@ -28,7 +28,7 @@
 
 <script type="text/javascript">
 function doSearch() {
-  document.location = '<?php echo base_path() ?>resource-browser#/search/' + document.getElementById('searchCriteria').value;
+  document.location = '<?php echo base_path() ?>resource-browser#/search/?type=ev&search=' + document.getElementById('searchCriteria').value;
 
 }
 </script>

--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -29,7 +29,7 @@
 
 <script type="text/javascript">
 function doSearch() {
-  document.location = '<?php echo base_path() ?>resource-browser#/search/' + document.getElementById('searchCriteria').value;
+  document.location = '<?php echo base_path() ?>resource-browser#/search/?type=ev&search=' + document.getElementById('searchCriteria').value;
 
 }
 </script>


### PR DESCRIPTION
Closes #487 - Fixes the calling format of the search form the headers
of the home page and other pages. Defaults to ev.
